### PR TITLE
feat: add OpenAI compatible API, fix Dockerfile, revert version of vl…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM vllm/vllm-openai:latest
+# FROM vllm/vllm-openai:latest
+FROM vllm/vllm-openai:v0.9.0
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
1. 添加 /audio/speech api 路径，兼容OpenAI 接口 #66 
2. 添加/audio/voices api 路径， 获得voice/character 列表 #66 


#75  修复docker-compose 出现的ValueError: 'aimv2' is already used by a Transformers config, pick another name错误， 将Dockerfile 使用的vllm版本固定为0.9.0, 与 requirements.txt 中指定的vllm版本相同。 